### PR TITLE
Treat character int literals with non-word chars as numbers

### DIFF
--- a/syntaxes/mercury.YAML-tmLanguage
+++ b/syntaxes/mercury.YAML-tmLanguage
@@ -146,4 +146,4 @@ repository:
 
   number:
     name: constant.numeric.source.mercury
-    match: \b(0(?!['])[0-7]*|0['].|[1-9][0-9]*|\.[0-9]+([eE][0-9]+)?|0[xX][0-9a-fA-F]+|0[bB][01]+)\b
+    match: \b0['].|\b(0(?!['])[0-7]*|[1-9][0-9]*|\.[0-9]+([eE][0-9]+)?|0[xX][0-9a-fA-F]+|0[bB][01]+)\b

--- a/syntaxes/mercury.tmLanguage
+++ b/syntaxes/mercury.tmLanguage
@@ -386,7 +386,7 @@
         <key>name</key>
         <string>constant.numeric.source.mercury</string>
         <key>match</key>
-        <string>\b(0(?!['])[0-7]*|0['].|[1-9][0-9]*|\.[0-9]+([eE][0-9]+)?|0[xX][0-9a-fA-F]+|0[bB][01]+)\b</string>
+        <string>\b0['].|\b(0(?!['])[0-7]*|[1-9][0-9]*|\.[0-9]+([eE][0-9]+)?|0[xX][0-9a-fA-F]+|0[bB][01]+)\b</string>
       </dict>
     </dict>
   </dict>


### PR DESCRIPTION
Before, a literal like `0'.` would be highlighted as the number `0` and
the unterminated string beginning `'.`. This was due to the `\b` word
boundary assertion at the end of the `number` pattern failing to match
after non-word characters.

<img width="539" alt="Screen Shot 2020-12-05 at 11 28 03 PM" src="https://user-images.githubusercontent.com/29010/101271863-cfeb0a80-3754-11eb-983f-fb30c1fac76e.png">


Now, the pattern does not assert a word boundary at the end for that
flavor of number, only at the beginning. It now correctly highlights
the problematic example.

<img width="615" alt="Screen Shot 2020-12-05 at 11 51 03 PM" src="https://user-images.githubusercontent.com/29010/101271865-d4172800-3754-11eb-98e9-d9d0ed10bd0d.png">


Fixes #1.